### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Port Scanner
 
 ![Screenshot_2022-08-12_20-10-21](https://user-images.githubusercontent.com/51499809/184459273-d1b4e031-8805-4148-96e6-29da209b891c.png)
+
+
+zip


### PR DESCRIPTION
Add module for Tiki Wiki unauthenticated RCE through File Upload vulnerability. Patch was released by vendor several days ago. (https://tiki.org/article434-Security-update-Tiki-15-2-Tiki-14-4-and-Tiki-12-9-released)

Installation
Download vulnerable version from Github (https://github.com/tikiorg/tiki/archive/15.1.zip)

Follow instructions for Debian on following URL (https://doc.tiki.org/Install+on+Debian)